### PR TITLE
Issue #10 - Use Prettier to format HTML, CSS and JSON files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
     "es2021": true,
     "webextensions": true
   },
-  "extends": ["eslint:recommended", "plugin:prettier/recommended"],
+  "extends": ["eslint:recommended", "prettier"],
   "parserOptions": {
     "ecmaVersion": 12,
     "sourceType": "module"

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,4 @@
 {
-  "endOfLine": "auto"
+  "endOfLine": "auto",
+  "tabWidth": 2
 }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Additionally, there is a migration page that is used to relocate the user's sett
 
 ### Building
 
-Building is done using [Webpack](https://webpack.js.org/). To build the "distribution" code, you first have to execute `yarn`, to install all dependencies, and then `yarn run build` to build once or `yarn run live` to watch file changes and rebuild on file change. These commands will create `dist` directory and copies all files into it and minifies them. Optionally, you can do `yarn run zip` for compress the content of the `dist` directory into a zip file (you can also do `yarn run build-zip` to execute both the build and zipping actions with a single command).
+Building is done using [Webpack](https://webpack.js.org/). To build the "distribution" code, you first have to execute `yarn`, to install all dependencies, and then `yarn run build` to build once or `yarn run live` to watch file changes and rebuild on file change. These commands will create `dist` directory and copies all files into it and minifies them. Optionally, you can do `yarn run zip` for compress the content of the `dist` directory into a zip file (you can also do `yarn run build:zip` to execute both the build and zipping actions with a single command).
 
 ### Packaging
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "private": true,
   "scripts": {
     "build": "webpack --config webpack.config.js",
-    "build-zip": "yarn run build && yarn run zip",
-    "lint": "eslint --ext js src",
-    "lint:fix": "eslint --ext js src --fix",
+    "build:zip": "yarn run build && yarn run zip",
+    "lint": "eslint src",
+    "lint:fix": "prettier --write src && eslint src --fix",
     "live": "webpack --config webpack.config.js --watch",
     "zip": "bestzip dist.zip dist/*"
   },
@@ -19,7 +19,6 @@
     "css-loader": "^5.2.4",
     "eslint": "^7.25.0",
     "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-prettier": "^3.4.0",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.3.1",
     "prettier": "2.3.0",

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -46,13 +46,13 @@ html.page-options h3 {
 }
 
 .sortable:nth-child(even) {
-  background-color: #F4F4F4;
+  background-color: #f4f4f4;
 }
 .sortable-chosen,
 .sortable.sortable-chosen {
-  background-color: #DFD;
+  background-color: #dfd;
 }
 .sortable-ghost,
 .sortable.sortable-ghost {
-  background-color: #DDF;
+  background-color: #ddf;
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -13,16 +13,8 @@
     "service_worker": "background.js"
   },
   "options_page": "options.html",
-  "permissions": [
-    "alarms",
-    "contextMenus",
-    "notifications",
-    "storage"
-  ],
-  "host_permissions": [
-    "http://*/*",
-    "https://*/*"
-  ],
+  "permissions": ["alarms", "contextMenus", "notifications", "storage"],
+  "host_permissions": ["http://*/*", "https://*/*"],
   "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCpwQdswwbWCDVkWd4XMJ1nxuzZYNmgnturk8DeuZgc85IPRiLyg5TTQKgSVjGU2s/i8a3qB/RsmMw7LR2V8f2L0z4qUO2CX3UfqeOtJMv1MkcUPTYBj7bOGe5sj4bFtKFMBD2YiSizlIFkFe63q0fr1QX6eF3DCBpgheYUTfmkzQIDAQAB",
   "homepage_url": "http://www.criticalstart.com/company/",
   "update_url": "https://clients2.google.com/service/update2/crx"

--- a/src/migration.html
+++ b/src/migration.html
@@ -5,7 +5,8 @@
 
   <body>
     <div class="text-center p-5">
-      <i class="fas fa-sync fa-spin"></i> Updating configuration from Threat Analytics Search extension...
+      <i class="fas fa-sync fa-spin"></i> Updating configuration from Threat
+      Analytics Search extension...
     </div>
   </body>
 </html>

--- a/src/postHandler.html
+++ b/src/postHandler.html
@@ -7,7 +7,9 @@
   </head>
   <body>
     <div id="target">
-      <h5 class="text-info text-center m-3"><i class="fas fa-sync fa-spin"></i> Loading...</h5>
+      <h5 class="text-info text-center m-3">
+        <i class="fas fa-sync fa-spin"></i> Loading...
+      </h5>
     </div>
     <script id="template" type="x-tmpl-mustache">
       <table class="table" aria-busy="{{ busy }}">

--- a/src/views/settings.html
+++ b/src/views/settings.html
@@ -169,86 +169,77 @@
     </div>
   </form>
 
-    <div class="row">
-      <div class="col-md-10 offset-md-1">
-        <h2 class="text-center mt-3">Export/Import Search Options</h2>
+  <div class="row">
+    <div class="col-md-10 offset-md-1">
+      <h2 class="text-center mt-3">Export/Import Search Options</h2>
 
-        <p>
-          Use Import and Export to share settings using a file. Otherwise, click
-          Edit to modify the settings manually. This requires knowing JSON
-          formatting well. We also recommend exporting a copy of your settings
-          prior to doing this.
-        </p>
+      <p>
+        Use Import and Export to share settings using a file. Otherwise, click
+        Edit to modify the settings manually. This requires knowing JSON
+        formatting well. We also recommend exporting a copy of your settings
+        prior to doing this.
+      </p>
 
-        <input class="d-none" id="settings_fileInput" type="file" />
+      <input class="d-none" id="settings_fileInput" type="file" />
 
-        <div class="text-right">
-          <button
-            type="button"
-            class="btn btn-primary mr-2"
-            id="settings_import"
-          >
-            <i class="fas fa-file-import" aria-hidden="true"></i> Import
-          </button>
-          <button
-            type="button"
-            class="btn btn-primary mr-2"
-            id="settings_export"
-          >
-            <i class="fas fa-file-export" aria-hidden="true"></i> Export
-          </button>
-          <button type="button" class="btn btn-secondary" id="settings_edit">
-            <i class="fas fa-edit" aria-hidden="true"></i> Edit manually
-          </button>
-        </div>
+      <div class="text-right">
+        <button type="button" class="btn btn-primary mr-2" id="settings_import">
+          <i class="fas fa-file-import" aria-hidden="true"></i> Import
+        </button>
+        <button type="button" class="btn btn-primary mr-2" id="settings_export">
+          <i class="fas fa-file-export" aria-hidden="true"></i> Export
+        </button>
+        <button type="button" class="btn btn-secondary" id="settings_edit">
+          <i class="fas fa-edit" aria-hidden="true"></i> Edit manually
+        </button>
       </div>
     </div>
+  </div>
 
-    <div
-      class="modal fade"
-      id="settings_editModal"
-      tabindex="-1"
-      role="dialog"
-      aria-labelledby="settingsEditModal"
-      aria-hidden="true"
-    >
-      <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title">Edit Changes</h5>
-            <button
-              type="button"
-              class="close"
-              id="settings_closeModal"
-              aria-label="Close"
-            >
-              <span aria-hidden="true">&times;</span>
-            </button>
-          </div>
-          <div class="modal-body">
-            <textarea
-              id="settings_json"
-              class="form-control text-monospace text-small"
-              rows="24"
-            >
-            </textarea>
-          </div>
-          <div class="modal-footer">
-            <button
-              type="button"
-              class="btn btn-secondary"
-              id="settings_discardChanges"
-            >
-              Discard
-            </button>
-            <button
-              type="button"
-              class="btn btn-success mr-2"
-              id="settings_saveChanges"
-            >
-              Save changes
-            </button>
-          </div>
+  <div
+    class="modal fade"
+    id="settings_editModal"
+    tabindex="-1"
+    role="dialog"
+    aria-labelledby="settingsEditModal"
+    aria-hidden="true"
+  >
+    <div class="modal-dialog modal-lg">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Edit Changes</h5>
+          <button
+            type="button"
+            class="close"
+            id="settings_closeModal"
+            aria-label="Close"
+          >
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <textarea
+            id="settings_json"
+            class="form-control text-monospace text-small"
+            rows="24"
+          >
+          </textarea>
+        </div>
+        <div class="modal-footer">
+          <button
+            type="button"
+            class="btn btn-secondary"
+            id="settings_discardChanges"
+          >
+            Discard
+          </button>
+          <button
+            type="button"
+            class="btn btn-success mr-2"
+            id="settings_saveChanges"
+          >
+            Save changes
+          </button>
         </div>
       </div>
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -863,13 +863,6 @@ eslint-config-prettier@^8.3.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
   integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
 
-eslint-plugin-prettier@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz#cdbad3bf1dbd2b177e9825737fe63b476a08f0c7"
-  integrity sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==
-  dependencies:
-    prettier-linter-helpers "^1.0.0"
-
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -1010,11 +1003,6 @@ fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-
-fast-diff@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
-  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.1.1, fast-glob@^3.2.5:
   version "3.2.5"
@@ -1847,13 +1835,6 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
-
-prettier-linter-helpers@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
-  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
-  dependencies:
-    fast-diff "^1.1.2"
 
 prettier@2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Fixes #10

Previous configuration was restricting Prettier to only format JS files, but now all files, on `src` folder, supported by Prettier should be formatted