### PR TITLE
Issue #54 - Allow to update URLs and Labels from Search Providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/AdvancedThreatAnalytics/threat-analytics-search.git",
   "private": true,
   "scripts": {
-    "build": "webpack --config webpack.config.js",
+    "build": "webpack --env mode=prod --mode=production --config webpack.config.js",
     "build:dev": "webpack --env mode=dev --mode=development --config webpack.config.js",
     "build:zip": "yarn run build && yarn run zip",
     "lint": "eslint src",

--- a/src/js/migration.js
+++ b/src/js/migration.js
@@ -121,10 +121,9 @@ function migrateGeneralSettings(defaultFile) {
 function migrateSearchProviders(defaultFile) {
   return LocalStore.setOne(
     StoreKey.SEARCH_PROVIDERS,
-    _.map(
+    ConfigFile.parseProviders(
       tryJSONparse(Storage.getItem("_allsearch")) ||
-        _.get(defaultFile, "searchproviders", []),
-      ConfigFile.parseProvider
+        _.get(defaultFile, "searchproviders", [])
     )
   );
 }
@@ -140,10 +139,9 @@ function migrateSpecialProvider(
     config:
       tryJSONparse(Storage.getItem(configKey)) ||
       _.get(defaultFile, `${fileKey}.Config`, {}),
-    queries: _.map(
+    queries: ConfigFile.parseQueries(
       tryJSONparse(Storage.getItem(queryKey)) ||
-        _.get(defaultFile, `${fileKey}.Queries`, []),
-      ConfigFile.parseQuery
+        _.get(defaultFile, `${fileKey}.Queries`, [])
     ),
   });
 }

--- a/src/js/shared/constants.js
+++ b/src/js/shared/constants.js
@@ -12,14 +12,6 @@ export const MiscURLs = {
   MIXPANEL_TRACK_URL: "https://api.mixpanel.com/track#live-event",
 };
 
-export const BasicConfig = {
-  CONFIG_URL: 0,
-  USE_GROUPS: 1,
-  ENCRYPTED: 2,
-  ENCRIPTION_KEY: 3,
-  AUTO_UPDATE: 4,
-};
-
 export const StoreKey = {
   CARBON_BLACK: "carbon_black",
   LAST_CONFIG_DATA: "last_config_data",
@@ -278,7 +270,6 @@ export const EXPORT_FILE_NAME = "Settings.json";
 
 export default {
   MiscURLs,
-  BasicConfig,
   StoreKey,
   CBC_CONFIG,
   CONFIG_FILE_OPTIONS,


### PR DESCRIPTION
Fixes #54 

This PR was created to fix the limitation detected on #53, in which changing the labels and URLs from search providers in the `settings.json` file would produce duplicate entries. Now, with these changes, configuration files can now include an `update` field for define bulk update action for search providers.

E.g.:

```json
   "update":{
      "providers":[
         {
            "target":[
               "http://www.google.com/search?q=TESTSEARCH",
               "https://google.com/search?q=TESTSEARCH"
            ],
            "link":"https://www.google.com/search?q=TESTSEARCH",
            "label":"Google Inc"
         }
      ]
   }
```