### PR TITLE
PIX-7898 - add resolution for minimatch to enforce >= 10.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "resolutions": {
     "strip-ansi": "^6.0.1",
     "ansi-regex": "^5.0.1",
-    "basic-ftp": "5.2.0"
+    "basic-ftp": "5.2.0",
+    "glob/minimatch": "^10.2.1"
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.14.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1713,22 +1713,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@isaacs/balanced-match@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@isaacs/balanced-match@npm:4.0.1"
-  checksum: 10/102fbc6d2c0d5edf8f6dbf2b3feb21695a21bc850f11bc47c4f06aa83bd8884fde3fe9d6d797d619901d96865fdcb4569ac2a54c937992c48885c5e3d9967fe8
-  languageName: node
-  linkType: hard
-
-"@isaacs/brace-expansion@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "@isaacs/brace-expansion@npm:5.0.1"
-  dependencies:
-    "@isaacs/balanced-match": "npm:^4.0.1"
-  checksum: 10/aec226065bc4285436a27379e08cc35bf94ef59f5098ac1c026495c9ba4ab33d851964082d3648d56d63eb90f2642867bd15a3e1b810b98beb1a8c14efce6a94
-  languageName: node
-  linkType: hard
-
 "@isaacs/fs-minipass@npm:^4.0.0":
   version: 4.0.1
   resolution: "@isaacs/fs-minipass@npm:4.0.1"
@@ -3053,6 +3037,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"balanced-match@npm:^4.0.2":
+  version: 4.0.4
+  resolution: "balanced-match@npm:4.0.4"
+  checksum: 10/fb07bb66a0959c2843fc055838047e2a95ccebb837c519614afb067ebfdf2fa967ca8d712c35ced07f2cd26fc6f07964230b094891315ad74f11eba3d53178a0
+  languageName: node
+  linkType: hard
+
 "bare-events@npm:^2.5.4, bare-events@npm:^2.7.0":
   version: 2.8.2
   resolution: "bare-events@npm:2.8.2"
@@ -3222,6 +3213,15 @@ __metadata:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
   checksum: 10/12cb6d6310629e3048cadb003e1aca4d8c9bb5c67c3c321bafdd7e7a50155de081f78ea3e0ed92ecc75a9015e784f301efc8132383132f4f7904ad1ac529c562
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^5.0.2":
+  version: 5.0.4
+  resolution: "brace-expansion@npm:5.0.4"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10/cfd57e20d8ded9578149e47ae4d3fff2b2f78d06b54a32a73057bddff65c8e9b930613f0cbcfefedf12dd117151e19d4da16367d5127c54f3bff02d8a4479bb2
   languageName: node
   linkType: hard
 
@@ -6611,12 +6611,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.1.2":
-  version: 10.1.2
-  resolution: "minimatch@npm:10.1.2"
+"minimatch@npm:^10.2.1":
+  version: 10.2.4
+  resolution: "minimatch@npm:10.2.4"
   dependencies:
-    "@isaacs/brace-expansion": "npm:^5.0.1"
-  checksum: 10/6f0ef975463739207144e411bdd54f7205ce38770b162fa3bc4c9be4987a16cb20d0962a82f26c2372598cfba90faa97b327239d303b529b774f17681c163b46
+    brace-expansion: "npm:^5.0.2"
+  checksum: 10/aea4874e521c55bb60744685bbffe3d152e5460f84efac3ea936e6bbe2ceba7deb93345fec3f9bb17f7b6946776073a64d40ae32bf5f298ad690308121068a1f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves PIX-7898.

Transitive dependency `minimatch` was resolving to `10.1.2` via `glob@13.0.1`, below the minimum safe version of `10.2.1`.

A blanket resolution was avoided to prevent forcing `minimatch@10.x` onto packages built against the v3 API (`eslint`, `readdir-glob`, `test-exclude`), which remain on `3.1.5` as intended.

## Changes
- Scoped resolution `glob/minimatch: ^10.2.1` to target only `glob`'s `minimatch` dependency.

## Verification
```
glob@13.0.1  → minimatch@10.2.4  ✓
glob@7.1.7   → minimatch@10.2.4  ✓ (dev/test only)
eslint        → minimatch@3.1.5   (unchanged, v3 API)
readdir-glob  → minimatch@3.1.5   (unchanged, v3 API)
test-exclude  → minimatch@3.1.5   (unchanged, v3 API)
```

## Security Fixes
* [minimatch has a ReDoS via repeated wildcards with non-matching literal in pattern](https://github.com/AdvancedThreatAnalytics/threat-analytics-search/security/dependabot/98)
* [minimatch has ReDoS: matchOne() combinatorial backtracking via multiple non-adjacent GLOBSTAR segments](https://github.com/AdvancedThreatAnalytics/threat-analytics-search/security/dependabot/102)
* [minimatch ReDoS: nested *() extglobs generate catastrophically backtracking regular expressions](https://github.com/AdvancedThreatAnalytics/threat-analytics-search/security/dependabot/101)