### PR TITLE
PIX-7900 - close browser pages after each post_handler e2e test to prevent OOM

### DIFF
--- a/tests/e2e/post_handler.spec.js
+++ b/tests/e2e/post_handler.spec.js
@@ -28,45 +28,49 @@ async function testPostHandler(sample, text) {
   // Go to options page
   const page = await ExtensionUtil.goto("options.html");
 
-  // Set sample provider on Chrome storage.
-  await page.evaluate(
-    (key, value) =>
-      new Promise((resolve) => {
-        const payload = {};
-        payload[key] = [value];
-        chrome.storage.local.set(payload, resolve);
-      }),
-    StoreKey.SEARCH_PROVIDERS,
-    sample
-  );
+  try {
+    // Set sample provider on Chrome storage.
+    await page.evaluate(
+      (key, value) =>
+        new Promise((resolve) => {
+          const payload = {};
+          payload[key] = [value];
+          chrome.storage.local.set(payload, resolve);
+        }),
+      StoreKey.SEARCH_PROVIDERS,
+      sample
+    );
 
-  // Set interceptor for requests.
-  await page.setRequestInterception(true);
-  page.on("request", interceptor);
+    // Set interceptor for requests.
+    await page.setRequestInterception(true);
+    page.on("request", interceptor);
 
-  const targetUrl = sample.link.replace(/TESTSEARCH/g, text);
-  const requestUrl = sample.proxyEnabled ? sample.proxyUrl : targetUrl;
-  const responsePromise = page.waitForResponse(requestUrl);
+    const targetUrl = sample.link.replace(/TESTSEARCH/g, text);
+    const requestUrl = sample.proxyEnabled ? sample.proxyUrl : targetUrl;
+    const responsePromise = page.waitForResponse(requestUrl);
 
-  // Go to post handler page.
-  const handlerUrl = `postHandler.html?name=${sample.label}&data=${text}`;
-  await ExtensionUtil.goto(handlerUrl, page);
+    // Go to post handler page.
+    const handlerUrl = `postHandler.html?name=${sample.label}&data=${text}`;
+    await ExtensionUtil.goto(handlerUrl, page);
 
-  // Check if POST request is made to the target or proxy URL.
-  const response = await responsePromise;
-  expect(response).toBeTruthy();
+    // Check if POST request is made to the target or proxy URL.
+    const response = await responsePromise;
+    expect(response).toBeTruthy();
 
-  // Check if post data is sent correctly.
-  const expectedData = sample.proxyEnabled
-    ? JSON.stringify({ url: targetUrl, data: sample.postValue })
-    : sample.postValue;
-  const postData = response.request().postData() || "";
-  expect(postData).toEqual(expectedData);
+    // Check if post data is sent correctly.
+    const expectedData = sample.proxyEnabled
+      ? JSON.stringify({ url: targetUrl, data: sample.postValue })
+      : sample.postValue;
+    const postData = response.request().postData() || "";
+    expect(postData).toEqual(expectedData);
 
-  // Check if request result is shown in UI.
-  const iconSelector = response.ok() ? ".fas.fa-check-circle" : ".fas.fa-ban";
-  const resultElem = await page.waitForSelector(iconSelector);
-  expect(resultElem).toBeTruthy();
+    // Check if request result is shown in UI.
+    const iconSelector = response.ok() ? ".fas.fa-check-circle" : ".fas.fa-ban";
+    const resultElem = await page.waitForSelector(iconSelector);
+    expect(resultElem).toBeTruthy();
+  } finally {
+    await page.close();
+  }
 }
 
 describe("Post Handler", () => {


### PR DESCRIPTION
Resolves PIX-7900.

Each call to testPostHandler() created a new Chrome page via ExtensionUtil.goto() but never closed it. Pages accumulated across the 3 tests, causing Chrome renderer processes to crash with OOM (error code 11) under memory pressure. This surfaced as intermittent 30s timeouts on 'POST handler with successful response' and 'POST handler with unsuccessful response'.

## Change
Wrapped the body of testPostHandler() in try/finally to ensure page.close() is always called after each test, whether it passes or fails.

## Verification
Ran the full e2e suite twice consecutively — all 9 tests passed both times.